### PR TITLE
Feature/parent child store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.2.0
+
+### Added
+- Added parent - child store relation to enable keeping state in one global state
+### Changed
+
 ## 1.1.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -151,6 +151,25 @@ install delegate in store
 
      store.doThings()
    ```
+
+## Parent-Child Store Relation
+
+You can create a child store derived from a parent store. This allows for state hoisting and synchronized state management.
+The child store is linked to the parent store via two mappers.
+
+```kotlin
+data class ParentState(val count: Int, val name: String)
+data class ChildState(val count: Int)
+
+val parentStore = Store(scope, ParentState(0, "Parent"))
+
+val childStore = parentStore.getChildStore(
+    scope = childScope,
+    initialState = ChildState(0),
+    parentToChild = { parent -> ChildState(parent.count) },
+    childToParent = { child -> copy(count = child.count) } // 'this' is ParentState
+)
+```
    
 ## QuickMVI - Compose
 ### Collecting state
@@ -184,4 +203,3 @@ For more use cases check:
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ buildscript {
 
 group = "io.github.mariuszmarzec"
 val postFix = "-SNAPSHOT".takeIf { System.getenv("SNAPSHOT").toBoolean() }.orEmpty()
-version = "1.1.0" + postFix
+version = "1.2.0" + postFix
 
 allprojects {
     repositories {

--- a/lib/src/commonMain/kotlin/com/marzec/mvi/ChildStore.kt
+++ b/lib/src/commonMain/kotlin/com/marzec/mvi/ChildStore.kt
@@ -1,0 +1,83 @@
+package com.marzec.mvi
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+fun <ParentState : Any, ChildState : Any> Store4<ParentState>.getChildStore(
+    scope: CoroutineScope,
+    initialState: ChildState,
+    parentToChild: (ParentState) -> ChildState,
+    childToParent: ParentState.(ChildState) -> ParentState
+): Store4<ChildState> {
+    val parentStore = this
+    val childStore = Store(scope, initialState)
+    childStore.stateInitializer = {
+        val parentStateFlow = parentStore.state as? MutableStateFlow<ParentState>
+            ?: throw IllegalStateException("Parent store state must be MutableStateFlow")
+
+        MappedStateFlow(
+            parentStateFlow,
+            parentToChild = parentToChild,
+            childToParent = childToParent,
+        )
+    }
+    return childStore
+}
+
+private class MappedStateFlow<T, R>(
+    private val origin: MutableStateFlow<T>,
+    private val parentToChild: (T) -> R,
+    private val childToParent: T.(R) -> T
+) : MutableStateFlow<R> {
+    override var value: R
+        get() = parentToChild(origin.value)
+        set(v) { origin.value = origin.value.childToParent(v) }
+
+    override val subscriptionCount: StateFlow<Int> = origin.subscriptionCount
+
+    override suspend fun emit(value: R) {
+        origin.emit(origin.value.childToParent(value))
+    }
+
+    override fun tryEmit(value: R): Boolean {
+        return origin.tryEmit(origin.value.childToParent(value))
+    }
+
+    override fun compareAndSet(expect: R, update: R): Boolean {
+        // This is tricky because we need the current parent state to calculate the new parent state
+        // But compareAndSet is atomic.
+        // If we use origin.value, it might change between read and compareAndSet.
+        // However, MutableStateFlow.compareAndSet compares the *new* value with the *current* value.
+        // Here we are mapping expectations.
+        // A strict implementation of compareAndSet for mapped flow with state dependency is hard/impossible without a lock or loop.
+        // But for StateFlow, compareAndSet is usually used to update if current value matches expect.
+
+        // Let's try a best effort approach or throw if not supported.
+        // Given the requirement "childToParent should mutate previous parent state",
+        // it implies we need the previous state.
+
+        // If we assume single threaded dispatcher for state updates (which MVI usually does),
+        // we might get away with reading origin.value.
+        val currentParent = origin.value
+        val expectedParent = currentParent.childToParent(expect)
+        val newParent = currentParent.childToParent(update)
+        return origin.compareAndSet(expectedParent, newParent)
+    }
+
+    override suspend fun collect(collector: FlowCollector<R>): Nothing {
+        origin.collect { value ->
+            collector.emit(parentToChild(value))
+        }
+    }
+
+    override val replayCache: List<R>
+        get() = origin.replayCache.map { parentToChild(it) }
+
+    @ExperimentalCoroutinesApi
+    override fun resetReplayCache() {
+        origin.resetReplayCache()
+    }
+}

--- a/lib/src/commonMain/kotlin/com/marzec/mvi/ChildStore.kt
+++ b/lib/src/commonMain/kotlin/com/marzec/mvi/ChildStore.kt
@@ -1,10 +1,7 @@
 package com.marzec.mvi
 
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.FlowCollector
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 
 fun <ParentState : Any, ChildState : Any> Store4<ParentState>.getChildStore(
     scope: CoroutineScope,
@@ -15,8 +12,8 @@ fun <ParentState : Any, ChildState : Any> Store4<ParentState>.getChildStore(
     val parentStore = this
     val childStore = Store(scope, initialState)
     childStore.stateInitializer = {
-        val parentStateFlow = parentStore.state as? MutableStateFlow<ParentState>
-            ?: throw IllegalStateException("Parent store state must be MutableStateFlow")
+        val parentStateFlow = parentStore.state as? StateContainer<ParentState>
+            ?: throw IllegalStateException("Parent store state must be StateContainer")
 
         MappedStateFlow(
             parentStateFlow,
@@ -28,43 +25,19 @@ fun <ParentState : Any, ChildState : Any> Store4<ParentState>.getChildStore(
 }
 
 private class MappedStateFlow<T, R>(
-    private val origin: MutableStateFlow<T>,
+    private val origin: StateContainer<T>,
     private val parentToChild: (T) -> R,
     private val childToParent: T.(R) -> T
-) : MutableStateFlow<R> {
-    override var value: R
+) : StateContainer<R> {
+    override val value: R
         get() = parentToChild(origin.value)
-        set(v) { origin.value = origin.value.childToParent(v) }
 
-    override val subscriptionCount: StateFlow<Int> = origin.subscriptionCount
-
-    override suspend fun emit(value: R) {
-        origin.emit(origin.value.childToParent(value))
-    }
-
-    override fun tryEmit(value: R): Boolean {
-        return origin.tryEmit(origin.value.childToParent(value))
-    }
-
-    override fun compareAndSet(expect: R, update: R): Boolean {
-        // This is tricky because we need the current parent state to calculate the new parent state
-        // But compareAndSet is atomic.
-        // If we use origin.value, it might change between read and compareAndSet.
-        // However, MutableStateFlow.compareAndSet compares the *new* value with the *current* value.
-        // Here we are mapping expectations.
-        // A strict implementation of compareAndSet for mapped flow with state dependency is hard/impossible without a lock or loop.
-        // But for StateFlow, compareAndSet is usually used to update if current value matches expect.
-
-        // Let's try a best effort approach or throw if not supported.
-        // Given the requirement "childToParent should mutate previous parent state",
-        // it implies we need the previous state.
-
-        // If we assume single threaded dispatcher for state updates (which MVI usually does),
-        // we might get away with reading origin.value.
-        val currentParent = origin.value
-        val expectedParent = currentParent.childToParent(expect)
-        val newParent = currentParent.childToParent(update)
-        return origin.compareAndSet(expectedParent, newParent)
+    override suspend fun update(function: (R) -> R) {
+        origin.update { parentState ->
+            val currentChildState = parentToChild(parentState)
+            val newChildState = function(currentChildState)
+            parentState.childToParent(newChildState)
+        }
     }
 
     override suspend fun collect(collector: FlowCollector<R>): Nothing {
@@ -75,9 +48,4 @@ private class MappedStateFlow<T, R>(
 
     override val replayCache: List<R>
         get() = origin.replayCache.map { parentToChild(it) }
-
-    @ExperimentalCoroutinesApi
-    override fun resetReplayCache() {
-        origin.resetReplayCache()
-    }
 }

--- a/lib/src/commonMain/kotlin/com/marzec/mvi/mvi.kt
+++ b/lib/src/commonMain/kotlin/com/marzec/mvi/mvi.kt
@@ -7,12 +7,15 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.newSingleThreadContext
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlin.experimental.ExperimentalTypeInference
 import kotlin.random.Random
@@ -28,7 +31,7 @@ interface Store4<State : Any> {
 
     val identifier: Any
 
-    var stateInitializer: () -> MutableStateFlow<State>
+    var stateInitializer: () -> StateContainer<State>
 
     var onNewStateCallback: (State) -> Unit
 
@@ -49,17 +52,43 @@ interface Store4<State : Any> {
     fun <Result : Any> run(id: String?, intent: Intent3<State, Result>)
 }
 
+interface StateContainer<State> : StateFlow<State> {
+    suspend fun update(function: (State) -> State)
+}
+
+class StateContainerImpl<State>(
+    private val defaultState: State
+) : StateContainer<State> {
+
+    private val _state = MutableStateFlow(defaultState)
+    private val mutex = Mutex()
+
+    override val replayCache: List<State>
+        get() = _state.replayCache
+    override val value: State
+        get() = _state.value
+
+    override suspend fun collect(collector: FlowCollector<State>): Nothing {
+        _state.collect(collector)
+    }
+
+    override suspend fun update(function: (State) -> State) {
+        mutex.withLock {
+            _state.update(function)
+        }
+    }
+}
 
 open class Store4Impl<State : Any>(
     private val scope: CoroutineScope,
     private val defaultState: State
 ) : Store4<State> {
 
-    override var stateInitializer: () -> MutableStateFlow<State> = { MutableStateFlow(defaultState) }
+    override var stateInitializer: () -> StateContainer<State> = { StateContainerImpl(defaultState) }
 
     override var onNewStateCallback: (State) -> Unit = { }
 
-    private val _state: MutableStateFlow<State> by lazy { stateInitializer() }
+    private val _state: StateContainer<State> by lazy { stateInitializer() }
 
     override val state: StateFlow<State>
         get() = _state
@@ -163,8 +192,9 @@ open class Store4Impl<State : Any>(
             runCancellationAndSideEffectIfNeeded(result, intent, jobId)
         } else {
             withContext(stateThread) {
-                val oldStateValue = _state.value
-                _state.update { intent.reducer(result, oldStateValue) }
+                _state.update { oldStateValue ->
+                    intent.reducer(result, oldStateValue)
+                }
                 onNewState(_state.value)
             }
             intent.sideEffect?.invoke(result, _state.value)

--- a/lib/src/commonTest/kotlin/com/marzec/mvi/StoreParentChildTest.kt
+++ b/lib/src/commonTest/kotlin/com/marzec/mvi/StoreParentChildTest.kt
@@ -1,0 +1,112 @@
+package com.marzec.mvi
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StoreParentChildTest {
+    private lateinit var parentScope: CoroutineScope
+    private lateinit var childScope: CoroutineScope
+
+    data class ParentState(val value: Int, val otherValue: String = "")
+    data class ChildState(val parentValue: Int)
+
+    private lateinit var parentStore: Store4<ParentState>
+    private lateinit var childStore: Store4<ChildState>
+
+    @BeforeTest
+    fun setUp() {
+        Store4Impl.stateThread = Dispatchers.Unconfined
+        parentScope = CoroutineScope(Dispatchers.Unconfined)
+        childScope = CoroutineScope(Dispatchers.Unconfined)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        parentScope.cancel()
+        childScope.cancel()
+    }
+
+    @Test
+    fun testGetChildStore() = runTest {
+        parentStore = Store(parentScope, ParentState(0))
+        childStore = parentStore.getChildStore(
+            scope = childScope,
+            initialState = ChildState(0),
+            parentToChild = { ChildState(it.value) },
+            childToParent = { copy(value = it.parentValue) }
+        )
+
+        // Initialize stores
+        val parentState = parentStore.state
+        val childState = childStore.state
+
+        assertEquals(ParentState(0), parentState.value)
+        assertEquals(ChildState(0), childState.value)
+
+        // When child state is updated, change is applied in parent
+        childStore.intent<Unit> {
+            reducer {
+                ChildState(1)
+            }
+        }
+
+        assertEquals(ChildState(1), childStore.state.value)
+        assertEquals(ParentState(1), parentStore.state.value)
+
+        // When parent change state, child also get notification about state change
+        parentStore.intent<Unit> {
+            reducer {
+                ParentState(2)
+            }
+        }
+
+        assertEquals(ParentState(2), parentStore.state.value)
+        assertEquals(ChildState(2), childStore.state.value)
+    }
+
+    @Test
+    fun testGetChildStoreWithComplexState() = runTest {
+        parentStore = Store(parentScope, ParentState(0, "initial"))
+        childStore = parentStore.getChildStore(
+            scope = childScope,
+            initialState = ChildState(0),
+            parentToChild = { ChildState(it.value) },
+            childToParent = { copy(value = it.parentValue) }
+        )
+
+        // Initialize stores
+        val parentState = parentStore.state
+        val childState = childStore.state
+
+        assertEquals(ParentState(0, "initial"), parentState.value)
+        assertEquals(ChildState(0), childState.value)
+
+        // When child state is updated, change is applied in parent but other fields are preserved
+        childStore.intent<Unit> {
+            reducer {
+                ChildState(1)
+            }
+        }
+
+        assertEquals(ChildState(1), childStore.state.value)
+        assertEquals(ParentState(1, "initial"), parentStore.state.value)
+
+        // When parent change state, child also get notification about state change
+        parentStore.intent<Unit> {
+            reducer {
+                ParentState(2, "updated")
+            }
+        }
+
+        assertEquals(ParentState(2, "updated"), parentStore.state.value)
+        assertEquals(ChildState(2), childStore.state.value)
+    }
+}


### PR DESCRIPTION
## Parent-Child Store Relation

You can create a child store derived from a parent store. This allows for state hoisting and synchronized state management.
The child store is linked to the parent store via two mappers.

```kotlin
data class ParentState(val count: Int, val name: String)
data class ChildState(val count: Int)

val parentStore = Store(scope, ParentState(0, "Parent"))

val childStore = parentStore.getChildStore(
    scope = childScope,
    initialState = ChildState(0),
    parentToChild = { parent -> ChildState(parent.count) },
    childToParent = { child -> copy(count = child.count) } // 'this' is ParentState
)
```